### PR TITLE
Fix wrong path pointing to old 1.5.0 folder structure - Closes #11

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,7 @@ class LiskNewRelic {
 			onError: this.errorHandler,
 		});
 
-		const controllerFolder = '/api/controllers/';
+		const controllerFolder = '/framework/src/modules/http_api/controllers/';
 		const controllerMethodExtractor = (shim, controller) =>
 			Object.getOwnPropertyNames(controller).filter(name =>
 				shim.isFunction(controller[name]),


### PR DESCRIPTION
### What was the problem?
API Controllers path is wrong and it's pointing to the old 1.5.0folder structure: api/controllers whereas now is framework/src/modules/http_api/controllers
### How did I fix it?
By changing the path for API Controllers instrumentation to the correct one: `framework/src/modules/http_api/controllers`
### How to test it?

### Review checklist

* The PR resolves #11 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
